### PR TITLE
Ren'Py Version Check for Screenshots

### DIFF
--- a/game/effects.rpy
+++ b/game/effects.rpy
@@ -6,7 +6,7 @@
 init python:
     # Screen caps the current screen used by many functions
     def screenshot_srf():
-        if renpy.version_only(2) >= 4:
+        if int(renpy.version()[7]) >= 7 and int(renpy.version()[9]) >= 4:
             srf = renpy.display.draw.screenshot(None)
         else:
             srf = renpy.display.draw.screenshot(None, False)

--- a/game/effects.rpy
+++ b/game/effects.rpy
@@ -6,7 +6,10 @@
 init python:
     # Screen caps the current screen used by many functions
     def screenshot_srf():
-        srf = renpy.display.draw.screenshot(None, False)
+        if renpy.version_only(2) >= 4:
+            srf = renpy.display.draw.screenshot(None)
+        else:
+            srf = renpy.display.draw.screenshot(None, False)
         
         return srf
 

--- a/game/options.rpy
+++ b/game/options.rpy
@@ -1,5 +1,5 @@
 ﻿# Options.rpy
-## This template version is 2.4.2. When asked to provide the template you are using,
+## This template version is 2.4.3. When asked to provide the template you are using,
 ## give them this version number. DO NOT REMOVE OR CHANGE THIS COMMENT.
    
 # This is where you will name your mod!
@@ -13,7 +13,7 @@ define gui.show_name = True
 # This is where you will input the version of your mod.
 # If you have multiple versions of your mod, this will be pretty useful to change.
 # If you are starting out, set this to "1.0"
-define config.version = "2.4.2"
+define config.version = "2.4.3"
 
 # This adds information about your mod in the About section.
 # DDLC does not have a about section so you can leave this blank.


### PR DESCRIPTION
## Versions Affected
Any Ren'Py 7.4+ DDLC Mod

## Issue Description
After 7.3.5, the Ren'Py code changed the method taking screenshots in the game works causing issues with certain effects in the game like `screen tear` when ran by a modder's copy in 7.4.0 or higher. 

## Cause
The cause of this is due to depreciation, or moved/removed feature in the `screenshot()` define in `swdraw.py` for `fullscreen_video` that has been present since 6.99.12.4 (Ren'Py 6) up to 7.3.5, when Ren'Py has officially removed support for fullscreen_video in the define itself. Since it takes less arguments than what Ren'Py 6 and older Ren'Py 7 had in the files, it will error out due to being given 2 arguments rather than one.

## Solution
The solution appears to be modifying `effects.rpy` to check whether the version of Ren'Py running is 7.4 or higher to use the new draw call and if not to use the older draw call from DDLC itself. This should fix the 2 argument screenshot error for future builds of the mod template and higher versions of Ren'Py.
