### PR TITLE
Ren'Py 7.4.6 - 7.4.8 Transform Patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![ko-fi](https://www.ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/K3K22K8SU)
 
-<u>Downloads</u>: [2.4.9 (Standard Template with Android Support)](https://github.com/GanstaKingofSA/DDLCModTemplate2.0/releases/2.4.9) | [2.3.1-u8 (Standard Template)](https://github.com/GanstaKingofSA/DDLCModTemplate2.0/releases/2.3.1-u8)
+<u>Downloads</u>: [2.5.0 (Standard Template with Android Support)](https://github.com/GanstaKingofSA/DDLCModTemplate2.0/releases/2.5.0) | [2.3.1-u9 (Standard Template)](https://github.com/GanstaKingofSA/DDLCModTemplate2.0/releases/2.3.1-u9)
 
 The **new** DDLC Mod Template is a mod template made by GanstaKingofSA for the **original** Doki Doki Literature Club that adheres to [Team Salvato's IP Guidelines](http://teamsalvato.com/ip-guidelines/) for fan mods on Ren'Py 6.99.12.4, 7.3.5 - 7.4.5 and 7.4.9 - 7.4.10.
 
@@ -39,6 +39,8 @@ Refer to [*guide.pdf*](guide.pdf) for more in-depth information about making you
 8. [BETA] Pronoun Support! Allow users to identify with what pronoun they go by!
     > See *pronoun_example.rpy* in the `game` folder for a example on how to use this feature.
 9. Better Blue Screens of Death! Make your own BSOD easily in-game now than ever on every operating system! (even Mac and Linux!)
+10. Uncensored Mode! Allow more sensitive content to be shown in-game.
+11. Let's Play Mode! 
 
 ### Added Features
 1. Terra's in-depth poem game guide!

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![ko-fi](https://www.ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/K3K22K8SU)
 
-<u>Downloads</u>: [2.5.0 (Standard Template with Android Support)](https://github.com/GanstaKingofSA/DDLCModTemplate2.0/releases/2.5.0) | [2.3.1-u9 (Standard Template)](https://github.com/GanstaKingofSA/DDLCModTemplate2.0/releases/2.3.1-u9)
+<u>Downloads</u>: 2.5.X (Standard Template with Android Support)<!--(https://github.com/GanstaKingofSA/DDLCModTemplate2.0/releases/2.5.0)--> | 2.3.1-uX (Standard Template)<!--(https://github.com/GanstaKingofSA/DDLCModTemplate2.0/releases/2.3.1-u9)-->
 
-The **new** DDLC Mod Template is a mod template made by GanstaKingofSA for the **original** Doki Doki Literature Club that adheres to [Team Salvato's IP Guidelines](http://teamsalvato.com/ip-guidelines/) for fan mods on Ren'Py 6.99.12.4, 7.3.5 - 7.4.5 and 7.4.9 - 7.4.10.
+The **new** DDLC Mod Template is a mod template made by GanstaKingofSA for the **original** Doki Doki Literature Club that adheres to [Team Salvato's IP Guidelines](http://teamsalvato.com/ip-guidelines/) for fan mods on Ren'Py 6.99.12.4 and Ren'Py 7.3.5 - 7.4.10.
 
 ### **<u>A request from the developer</u>**
 > If the template has been useful to you, please credit me in your mods' release. Not all mod tool developers are thanked as much as regular mod teams by people outside the modding community and it will be appreciated to credit those that put the effort into making modding easier for you to make your own mod for others to enjoy.

--- a/game/README.md
+++ b/game/README.md
@@ -53,6 +53,10 @@ This text file contains all the poem words, and points that the character likes 
 
 This file showcases a examole of the pronoun system implemented in Version 2.4.8 of the mod template for players that go by different pronouns. This is not part of DDLC.
 
+### **renpy_patches.rpy**
+
+This file was introduced in Version 2.5.X of the mod template. It's purpose is to patch problematic code that can affect DDLC/DDLC mods on certain versions of Ren'Py that is tied to the Ren'Py engine itself. DO NOT MODIFY THIS FILE WHATSOEVER UNLESS YOU KNOW WHAT IS IN IT.
+
 ### **screens.rpy**
 
 This file controls the main menu and settings interface look for images, transforms, styles and such in the original game. This should be the file you look into if you want to customize your menu to be something different.

--- a/game/definitions.rpy
+++ b/game/definitions.rpy
@@ -1389,6 +1389,10 @@ default himC = persistent.him.capitalize()
 default areC = persistent.are.capitalize()
 default hesC = persistent.hes.capitalize()
 
+# Extra Settings Variables
+default persistent.uncensored_mode = False
+default persistent.lets_play = False
+
 # Persistent Variables
 
 # These variables are load at game startup and exist on all saves.

--- a/game/options.rpy
+++ b/game/options.rpy
@@ -13,7 +13,7 @@ define gui.show_name = True
 # This is where you will input the version of your mod.
 # If you have multiple versions of your mod, this will be pretty useful to change.
 # If you are starting out, set this to "1.0"
-define config.version = "2.4.9"
+define config.version = "2.5.0"
 
 # This adds information about your mod in the About section.
 # DDLC does not have a about section so you can leave this blank.

--- a/game/renpy_patches.rpy
+++ b/game/renpy_patches.rpy
@@ -1,0 +1,94 @@
+# Renpy_patches.rpy
+
+# This file is not part of DDLC. This file is mainly designed to 
+# patch certain versions of Ren'Py that break DDLC/DDLC mods by
+# patching the Ren'Py engine at startup.
+### DO NOT MODIFY THIS FILE WHATSOEVER! ###
+
+init -1 python:
+
+    if renpy.version_tuple >= (7, 4, 6, 1693) and renpy.version_tuple < (7, 4, 9, 2142):
+
+        # Patches the 7.4.6 - 7.4.8 transform bugs. Based off 7.4.9
+        class NewSceneLists(renpy.display.core.SceneLists):
+
+            @staticmethod
+            def add(self,
+                layer,
+                thing,
+                key=None,
+                zorder=0,
+                behind=[ ],
+                at_list=[ ],
+                name=None,
+                atl=None,
+                default_transform=None,
+                transient=False,
+                keep_st=False):
+
+                if not isinstance(thing, renpy.display.core.Displayable):
+                    raise Exception("Attempting to show something that isn't a displayable:" + repr(thing))
+
+                if layer not in self.layers:
+                    raise Exception("Trying to add something to non-existent layer '%s'." % layer)
+
+                if key:
+                    self.remove_hide_replaced(layer, key)
+                    self.at_list[layer][key] = at_list
+
+                if key and name:
+                    self.shown.predict_show(layer, name)
+
+                if transient:
+                    self.additional_transient.append((layer, key))
+
+                l = self.layers[layer]
+
+                if atl:
+                    thing = renpy.display.motion.ATLTransform(atl, child=thing)
+
+                add_index, remove_index, zorder = self.find_index(layer, key, zorder, behind)
+
+                at = None
+                st = None
+
+                if remove_index is not None:
+                    sle = l[remove_index]
+                    old = sle.displayable
+
+                    at = sle.animation_time
+
+                    if keep_st:
+                        st = sle.show_time
+
+                    if (not atl and
+                            not at_list and
+                            renpy.config.keep_running_transform and
+                            isinstance(old, renpy.display.motion.Transform)):
+
+                        thing = sle.displayable._change_transform_child(thing)
+                    else:
+                        thing = self.transform_state(l[remove_index].displayable, thing)
+
+                    thing.set_transform_event("replace")
+
+                else:
+
+                    if not isinstance(thing, renpy.display.motion.Transform):
+                        thing = self.transform_state(default_transform, thing)
+
+                    thing.set_transform_event("show")
+
+                sle = renpy.display.core.SceneListEntry(key, zorder, st, at, thing, name)
+                l.insert(add_index, sle)
+                
+                if remove_index is not None:
+                    if add_index <= remove_index:
+                        remove_index += 1
+
+                    self.hide_or_replace(layer, remove_index, "replaced")
+
+                # use visit_all than _show() due to depreciation
+                thing.visit_all(lambda d : None)
+        
+        renpy.display.core.SceneLists.add = NewSceneLists.add

--- a/game/screens.rpy
+++ b/game/screens.rpy
@@ -985,7 +985,7 @@ screen preferences():
                         label _("Extra Settings")
                         textbutton _("Uncensored Mode") action If(persistent.uncensored_mode, 
                             ToggleField(persistent, "uncensored_mode"), 
-                            Show("confirm", message="Are you sure you want to turn on Uncensored Mode?\nDoing so will enable more adult\nor sensitive content in your playthrough.", 
+                            Show("confirm", message="Are you sure you want to turn on Uncensored Mode?\nDoing so will enable more adult or sensitive\ncontent in your playthrough.\n\nThis setting will be dependent on the modder if\nthey programmed these checks in their story.", 
                                 yes_action=[Hide("confirm"), ToggleField(persistent, "uncensored_mode")],
                                 no_action=Hide("confirm")
                             ))

--- a/game/screens.rpy
+++ b/game/screens.rpy
@@ -4,6 +4,9 @@
 
 init offset = -1
 
+# Enables the ability to add more settings in the game such as uncensored mode.
+default extra_settings = True
+
 ## Color Styles
 ################################################################################
 
@@ -946,7 +949,10 @@ screen preferences():
     use game_menu(_("Settings"), scroll="viewport"):
 
         vbox:
-            xoffset 50
+            if extra_settings:
+                xoffset 35
+            else:
+                xoffset 50
 
             hbox:
                 box_wrap True
@@ -956,7 +962,7 @@ screen preferences():
                     vbox:
                         style_prefix "radio"
                         label _("Display")
-                        textbutton _("Window") action Preference("display", "window")
+                        textbutton _("Windowed") action Preference("display", "window")
                         textbutton _("Fullscreen") action Preference("display", "fullscreen")
                 if config.developer:
                     vbox:
@@ -972,6 +978,24 @@ screen preferences():
                     textbutton _("Unseen Text") action Preference("skip", "toggle")
                     textbutton _("After Choices") action Preference("after choices", "toggle")
                     #textbutton _("Transitions") action InvertSelected(Preference("transitions", "toggle"))
+                
+                if extra_settings:
+                    vbox:
+                        style_prefix "check"
+                        label _("Extra Settings")
+                        textbutton _("Uncensored Mode") action If(persistent.uncensored_mode, 
+                            ToggleField(persistent, "uncensored_mode"), 
+                            Show("confirm", message="Are you sure you want to turn on Uncensored Mode?\nDoing so will enable more adult\nor sensitive content in your playthrough.", 
+                                yes_action=[Hide("confirm"), ToggleField(persistent, "uncensored_mode")],
+                                no_action=Hide("confirm")
+                            ))
+                        textbutton _("Let's Play Mode") action If(persistent.lets_play, 
+                            ToggleField(persistent, "lets_play"),
+                            [ToggleField(persistent, "lets_play"), Show("dialog", 
+                                message="You have enabled Let's Play Mode.\nThis mode allows you to skip content that contains\nsensitive information or apply alternative\nstory options such as non-cover songs.\n\nThis setting will be dependent on the modder\nif they programmed these checks in their story.", 
+                                ok_action=Hide("dialog")
+                            )])
+                            
 
                 ## Additional vboxes of type "radio_pref" or "check_pref" can be
                 ## added here, to add additional creator-defined preferences.
@@ -979,6 +1003,8 @@ screen preferences():
             null height (4 * gui.pref_spacing)
 
             hbox:
+                if extra_settings:
+                    xoffset 15
                 style_prefix "slider"
                 box_wrap True
 
@@ -994,7 +1020,9 @@ screen preferences():
                     bar value Preference("auto-forward time")
 
                 vbox:
-
+                    if extra_settings:
+                        xoffset 15
+                    
                     if config.has_music:
                         label _("Music Volume")
 

--- a/game/screens.rpy
+++ b/game/screens.rpy
@@ -985,14 +985,14 @@ screen preferences():
                         label _("Extra Settings")
                         textbutton _("Uncensored Mode") action If(persistent.uncensored_mode, 
                             ToggleField(persistent, "uncensored_mode"), 
-                            Show("confirm", message="Are you sure you want to turn on Uncensored Mode?\nDoing so will enable more adult or sensitive\ncontent in your playthrough.\n\nThis setting will be dependent on the modder if\nthey programmed these checks in their story.", 
+                            Show("confirm", message="Are you sure you want to turn on Uncensored Mode?\nDoing so will enable more adult/sensitive\ncontent in your playthrough.\n\nThis setting will be dependent on the modder if\nthey programmed these checks in their story.", 
                                 yes_action=[Hide("confirm"), ToggleField(persistent, "uncensored_mode")],
                                 no_action=Hide("confirm")
                             ))
                         textbutton _("Let's Play Mode") action If(persistent.lets_play, 
                             ToggleField(persistent, "lets_play"),
                             [ToggleField(persistent, "lets_play"), Show("dialog", 
-                                message="You have enabled Let's Play Mode.\nThis mode allows you to skip content that contains\nsensitive information or apply alternative\nstory options such as non-cover songs.\n\nThis setting will be dependent on the modder\nif they programmed these checks in their story.", 
+                                message="You have enabled Let's Play Mode.\nThis mode allows you to skip content that\ncontains sensitive information or apply alternative\nstory options.\n\nThis setting will be dependent on the modder\nif they programmed these checks in their story.", 
                                 ok_action=Hide("dialog")
                             )])
                             

--- a/game/screens.rpy
+++ b/game/screens.rpy
@@ -468,6 +468,8 @@ screen navigation():
 
             textbutton _("Load Game") action [ShowMenu("load"), SensitiveIf(renpy.get_screen("load") == None)]
 
+            textbutton _("Gallery") action [ShowMenu("gallery"), SensitiveIf(renpy.get_screen("gallery") == None)]
+
             if _in_replay:
 
                 textbutton _("End Replay") action EndReplay(confirm=True)
@@ -1694,6 +1696,22 @@ screen nvl_dialogue(dialogue):
                 text d.what:
                     id d.what_id
 
+## BSOD screen ##################################################################
+##
+## This screen is used to fake a BSOD/kernel panic on the players' computer 
+## on all platforms (Mobile devices defaults to the Linux BSOD).
+##
+## Syntax:
+##     bsodCode - The error code message you want to show the player. Defaults to 
+##                DDLC_ESCAPE_PLAN_FAILED if no message is given.
+##     bsodFile (Windows 7 and Linux Only) - The fake file name that caused the 
+##                error. Defaults to libGLESv2.dll if no file name is given.
+##     rsod (Windows 11 Only) - Swaps the Windows 11 BSOD with a RSOD.
+##
+## Examples:
+##     show screen bsod("DOKI_DOKI", "renpy32.dll", False) 
+##     show screen bsod("TAKE_TWO_INTERACTIVE", rsod=True) 
+
 init python:
     import subprocess
 
@@ -1730,27 +1748,11 @@ init python:
     if renpy.windows:
         osName = subprocess.check_output("wmic os get version", shell=True).replace("\r", "").replace(" ", "").replace("\n", "").replace("Version ", "")
 
-## BSOD screen ##################################################################
-##
-## This screen is used to fake BSOD/kernel panic a player's computer on all
-## platforms (Mobile devices defaults to the Linux BSOD).
-##
-## Syntax:
-##     bsodCode - The error code message you want to show the player. Defaults to 
-##                DDLC_ESCAPE_PLAN_FAILED if no message is given.
-##     bsodFile (Windows 7 and Linux Only) - The fake file name that caused the 
-##                error. Defaults to libGLESv2.dll if no file name is given.
-##     rsod (Windows 11 Only) - Swaps the Windows 11 BSOD with a RSOD.
-##
-## Examples:
-##     show screen bsod("DOKI_DOKI", "renpy32.dll", False) 
-##     show screen bsod("TAKE_TWO_INTERACTIVE", rsod=True) 
-
 screen bsod(bsodCode="DDLC_ESCAPE_PLAN_FAILED", bsodFile="libGLESv2.dll", rsod=False):
 
     layer "master"
 
-    if renpy.windows:
+    if not renpy.windows:
 
         if osName < "6.2.9200": # Windows 7
             
@@ -1857,7 +1859,7 @@ screen bsod(bsodCode="DDLC_ESCAPE_PLAN_FAILED", bsodFile="libGLESv2.dll", rsod=F
                             text "If you call a support person, give them this info:" style "bsod_win10_sub_text" 
                             text "Stop code: " + bsodCode.upper() style "bsod_win10_sub_text"
         
-    elif renpy.macintosh:
+    elif not renpy.macintosh:
 
         add Solid("#222")
 
@@ -1919,73 +1921,68 @@ screen bsod(bsodCode="DDLC_ESCAPE_PLAN_FAILED", bsodFile="libGLESv2.dll", rsod=F
 
     add Solid("#000000") at bsod_transition
 
-if renpy.windows:
-    style bsod_win7_text is gui_text
-    style bsod_win7_text:
-        font "C:/Windows/Fonts/lucon.ttf"
-        antialias False
-        size 13
-        line_leading 15
-        line_spacing -14
-        xsize 1279
-        outlines []
+style bsod_win7_text is gui_text
+style bsod_win7_text:
+    font "C:/Windows/Fonts/lucon.ttf"
+    antialias False
+    size 13
+    line_leading 15
+    line_spacing -14
+    xsize 1279
+    outlines []
 
-    style bsod_win8_text is gui_text
-    style bsod_win8_text:
-        font "C:/Windows/Fonts/segoeuil.ttf"
-        size 25
-        line_spacing 5
-        xsize 600
-        outlines []
+style bsod_win8_text is gui_text
+style bsod_win8_text:
+    font "C:/Windows/Fonts/segoeuil.ttf"
+    size 25
+    line_spacing 5
+    xsize 600
+    outlines []
 
-    style bsod_win8_sad_text is gui_text
-    style bsod_win8_sad_text is bsod_win8_text:
-        size 128
-        xpos -8
+style bsod_win8_sad_text is gui_text
+style bsod_win8_sad_text is bsod_win8_text:
+    size 128
+    xpos -8
 
-    style bsod_win8_sub_text is gui_text
-    style bsod_win8_sub_text is bsod_win8_text:
-        size 11
+style bsod_win8_sub_text is gui_text
+style bsod_win8_sub_text is bsod_win8_text:
+    size 11
 
-    style bsod_win10_text is bsod_win8_text
-    style bsod_win10_text:
-        font "C:/Windows/Fonts/segoeuil.ttf"
-        size 24
-        line_leading 3
-        line_spacing 0
-        xsize 800
-        outlines []
+style bsod_win10_text is bsod_win8_text
+style bsod_win10_text:
+    font "C:/Windows/Fonts/segoeuil.ttf"
+    size 24
+    line_leading 3
+    line_spacing 0
+    xsize 800
+    outlines []
 
-    style bsod_win10_info_text is bsod_win10_text
-    style bsod_win10_info_text:
-        size 16
+style bsod_win10_info_text is bsod_win10_text
+style bsod_win10_info_text:
+    size 16
 
-    style bsod_win10_sad_text is bsod_win10_text
-    style bsod_win10_sad_text:
-        size 136
-        xpos -8
+style bsod_win10_sad_text is bsod_win10_text
+style bsod_win10_sad_text:
+    size 136
+    xpos -8
 
-    style bsod_win10_sub_text is bsod_win10_text
-    style bsod_win10_sub_text:
-        size 11
+style bsod_win10_sub_text is bsod_win10_text
+style bsod_win10_sub_text:
+    size 11
 
-elif renpy.macintosh:
+style bsod_mac_text is gui_text
+style bsod_mac_text:
+    font gui.default_font
+    size 28
+    outlines []
+    line_spacing -30
 
-    style bsod_mac_text is gui_text
-    style bsod_mac_text:
-        font gui.default_font
-        size 28
-        outlines []
-        line_spacing -30
-
-else:
-
-    style bsod_linux_text is gui_text
-    style bsod_linux_text:
-        font "gui/font/F25_Bank_Printer.ttf"
-        size 15
-        outlines []
-        line_leading 5
+style bsod_linux_text is gui_text
+style bsod_linux_text:
+    font "gui/font/F25_Bank_Printer.ttf"
+    size 15
+    outlines []
+    line_leading 5
             
 transform bsod_transition:
     "black"
@@ -2058,3 +2055,54 @@ style nvl_button:
 style nvl_button_text:
     properties gui.button_text_properties("nvl_button")
 
+## Gallery screen ##################################################################
+##
+## This screen is used to make a gallery view of 
+## in-game art to the player in the main menu.
+##
+## Syntax:
+##     g.button - sets the button name
+##     g.image - declares the type of image being used
+##     g.transition - customizes fade-in/out of images
+##     g.make_button - makes a button with the button and image names to view
+##                     the given art.
+##
+## More info: https://renpy.org/doc/html/rooms.html?highlight=gallery#image-gallery
+
+init python:
+    g = Gallery() 
+
+    g.button("disclaimer_two")
+    g.image("warning2")
+    
+    g.transition = dissolve
+
+screen gallery:
+
+    tag menu
+
+    use game_menu(_("Gallery")):
+        
+        vpgrid:
+            id "gvp"
+            rows 2
+            cols 3
+            spacing 25
+            mousewheel True
+
+            xalign 0.5
+            yalign 0.5
+
+            # Call make_button to show a particular button.
+            add g.make_button("disclaimer_two", "bg/warning2.png") at gallery_descale(renpy.image_size("bg/warning2.png"))
+            add g.make_button("disclaimer_two", "bg/warning2.png") at gallery_descale(renpy.image_size("bg/warning2.png"))
+            add g.make_button("disclaimer_two", "bg/warning2.png") at gallery_descale(renpy.image_size("bg/warning2.png"))
+
+            add g.make_button("disclaimer_two", "bg/warning2.png") at gallery_descale(renpy.image_size("bg/warning2.png"))
+            add g.make_button("disclaimer_two", "bg/warning2.png") at gallery_descale(renpy.image_size("bg/warning2.png"))
+            add g.make_button("disclaimer_two", "bg/warning2.png") at gallery_descale(renpy.image_size("bg/warning2.png"))
+        
+        vbar value YScrollValue("gvp") xalign 0.99 ysize 560
+
+transform gallery_descale(img):
+    size(int(img[0] / 5), int(img[1] / 5))

--- a/game/screens.rpy
+++ b/game/screens.rpy
@@ -1741,6 +1741,10 @@ init python:
 ##     bsodFile (Windows 7 and Linux Only) - The fake file name that caused the 
 ##                error. Defaults to libGLESv2.dll if no file name is given.
 ##     rsod (Windows 11 Only) - Swaps the Windows 11 BSOD with a RSOD.
+##
+## Examples:
+##     show screen bsod("DOKI_DOKI", "renpy32.dll", False) 
+##     show screen bsod("TAKE_TWO_INTERACTIVE", rsod=True) 
 
 screen bsod(bsodCode="DDLC_ESCAPE_PLAN_FAILED", bsodFile="libGLESv2.dll", rsod=False):
 

--- a/game/script-poemgame.rpy
+++ b/game/script-poemgame.rpy
@@ -10,6 +10,16 @@
 init python: #This whole block runs when DDLC is started (as opposed to when the poem minigame is called)
     import random
 
+    if renpy.android and renpy.version_tuple == (6, 99, 12, 4, 2187): # Android Poem Game Check for 6.99
+        poem_txt = os.environ['ANDROID_PUBLIC'] + "/game/poemwords.txt"
+        try:
+            if not os.access(os.environ['ANDROID_PUBLIC'] + "/game/", os.F_OK):
+                os.mkdir(os.environ['ANDROID_PUBLIC'] + "/game")
+            file(poem_txt)
+        except: open(poem_txt, "wb").write(renpy.file("poemwords.txt").read())
+    else:
+        poem_txt = "poemwords.txt"
+
     # This class holds a word, and point values for each of the four heroines
     class PoemWord:
         def __init__(self, word, sPoint, nPoint, yPoint, glitch=False):
@@ -25,7 +35,7 @@ init python: #This whole block runs when DDLC is started (as opposed to when the
 
     # Building the word list
     full_wordlist = []
-    with renpy.file("poemwords.txt") as wordfile:
+    with renpy.file(poem_txt) as wordfile:
         for line in wordfile:
             # Ignore lines beginning with '#' and empty lines
             line = line.strip()

--- a/game/splash.rpy
+++ b/game/splash.rpy
@@ -6,7 +6,7 @@
 ## and decompile them for the builds to work.
 init -100 python:
     if not renpy.android:
-        for archive in ['audio','images','scripts','fonts']:
+        for archive in ['audio','images','fonts']:
             if archive not in config.archives:
                 renpy.error("DDLC archive files not found in /game folder. Check your installation and try again.")
 


### PR DESCRIPTION
This PR does the following

## Fixes
- Patched a engine bug from 7.4.6 to 7.4.8 where characters would instantly disappear when calling `thide` and other transforms in DDLC
- Patched a engine bug in 7.4.6 where characters will refuse to appear when called on.

## Notes
- This PR will require a additional file to be added: `renpy_patches.rpy` 