### PR TITLE
Different Menu Button Colors

### DIFF
--- a/game/screens.rpy
+++ b/game/screens.rpy
@@ -290,14 +290,43 @@ style input:
 ## statement. The one parameter, items, is a list of objects, each with caption
 ## and action fields.
 ##
+## New as of 2.5.0
+##    - You may now pass through argurments to the menu options to colorize
+##      your menu as you like. Add (kwargs=[color hex or style name]) to your
+##      menu option name and you get different buttons! 
+##
+##      Ex: "Option 1 (kwargs="#00fbff")
+##
 ## http://www.renpy.org/doc/html/screen_special.html#choice
 
 screen choice(items):
     style_prefix "choice"
 
     vbox:
+
         for i in items:
-            textbutton i.caption action i.action
+            
+            if "kwarg=" in i.caption:
+
+                $ kwarg = i.caption.split("(kwarg=")[-1].replace(")", "")
+                $ caption = i.caption.replace(" (kwarg=" + kwarg + ")", "")
+
+                if "#" in kwarg:
+                    
+                    textbutton caption:
+                        idle_background Frame(im.MatrixColor("gui/button/choice_idle_background.png", im.matrix.desaturate() * im.matrix.colorize(kwarg, "#fff") * im.matrix.saturation(7.0)), gui.choice_button_borders)
+                        hover_background Frame(im.MatrixColor("gui/button/choice_idle_background.png", im.matrix.desaturate() * im.matrix.colorize(kwarg, "#fff") * im.matrix.saturation(7.0)), gui.choice_button_borders)
+                        action i.action
+
+                else:
+
+                    textbutton caption:
+                        style kwarg
+                        action i.action
+
+            else:
+
+                textbutton i.caption action i.action
 
 
 ## When this is true, menu captions will be spoken by the narrator. When false,

--- a/game/screens.rpy
+++ b/game/screens.rpy
@@ -290,7 +290,7 @@ style input:
 ## statement. The one parameter, items, is a list of objects, each with caption
 ## and action fields.
 ##
-## New as of 2.5.0
+## New as of 3.0.0
 ##    - You may now pass through argurments to the menu options to colorize
 ##      your menu as you like. Add (kwargs=[color hex or style name]) to your
 ##      menu option name and you get different buttons! 

--- a/game/screens.rpy
+++ b/game/screens.rpy
@@ -313,9 +313,19 @@ screen choice(items):
 
                 if "#" in kwarg:
                     
+                    $ kwarg = kwarg.replace(", ", ",").split(",")
+                    
+                    if len(kwarg) == 1:
+                        $ kwarg.append('#ffe6f4')
+                    
+                    $ arg1 = kwarg[0]
+                    $ arg2 = kwarg[-1]
+                    
                     textbutton caption:
-                        idle_background Frame(im.MatrixColor("gui/button/choice_idle_background.png", im.matrix.desaturate() * im.matrix.colorize(kwarg, "#fff") * im.matrix.saturation(18.5)), gui.choice_button_borders)
-                        hover_background Frame(im.MatrixColor("gui/button/choice_hover_background.png", im.matrix.desaturate() * im.matrix.colorize(kwarg, "#fff") * im.matrix.saturation(18.5)), gui.choice_button_borders)
+                        idle_background Frame(im.MatrixColor(im.MatrixColor("gui/button/choice_idle_background.png", im.matrix.desaturate() * im.matrix.contrast(1.29) * im.matrix.colorize("#00f", "#fff") * im.matrix.saturation(120)), 
+                            im.matrix.desaturate() * im.matrix.colorize(arg1, arg2)), gui.choice_button_borders)
+                        hover_background Frame(im.MatrixColor(im.MatrixColor("gui/button/choice_hover_background.png", im.matrix.desaturate() * im.matrix.contrast(1.29) * im.matrix.colorize("#00f", "#fff") * im.matrix.saturation(120)), 
+                            im.matrix.desaturate() * im.matrix.colorize(arg1, "#fff")), gui.choice_button_borders)
                         action i.action
 
                 else:

--- a/game/screens.rpy
+++ b/game/screens.rpy
@@ -295,7 +295,7 @@ style input:
 ##      your menu as you like. Add (kwargs=[color hex or style name]) to your
 ##      menu option name and you get different buttons! 
 ##
-##      Ex: "Option 1 (kwargs="#00fbff")
+##      Examples: "Option 1 (kwargs=#00fbff)" | "Option 2 (kwargs=#00fbff, #6cffff)"
 ##
 ## http://www.renpy.org/doc/html/screen_special.html#choice
 

--- a/game/screens.rpy
+++ b/game/screens.rpy
@@ -314,8 +314,8 @@ screen choice(items):
                 if "#" in kwarg:
                     
                     textbutton caption:
-                        idle_background Frame(im.MatrixColor("gui/button/choice_idle_background.png", im.matrix.desaturate() * im.matrix.colorize(kwarg, "#fff") * im.matrix.saturation(7.0)), gui.choice_button_borders)
-                        hover_background Frame(im.MatrixColor("gui/button/choice_idle_background.png", im.matrix.desaturate() * im.matrix.colorize(kwarg, "#fff") * im.matrix.saturation(7.0)), gui.choice_button_borders)
+                        idle_background Frame(im.MatrixColor("gui/button/choice_idle_background.png", im.matrix.desaturate() * im.matrix.colorize(kwarg, "#fff") * im.matrix.saturation(18.5)), gui.choice_button_borders)
+                        hover_background Frame(im.MatrixColor("gui/button/choice_hover_background.png", im.matrix.desaturate() * im.matrix.colorize(kwarg, "#fff") * im.matrix.saturation(18.5)), gui.choice_button_borders)
                         action i.action
 
                 else:


### PR DESCRIPTION
This PR is inspired by [this](https://www.reddit.com/r/DDLCMods/comments/r8psvj/not_sure_it_was_worth_a_full_week_of_banging_my/) Reddit post and does the following.

## Features
- Adds different color menu button support for the choice menu via a given color hex or style name.

## Example syntax
```py
menu:
    "Option 1": # Normal Button
        pass
    "Option 2 (kwarg=#ff0)": # Color Hex Button
        pass
    "Option 3 (kwarg=choice_button_custom)": # Custom Style Button
        pass
```