### PR TITLE
use 'Composite' instead of 'LiveComposite?'

### DIFF
--- a/game/mod_extras/extras_screen.rpy
+++ b/game/mod_extras/extras_screen.rpy
@@ -31,8 +31,8 @@ screen extras():
                         xalign 0.5
                         yalign 0.5
                         imagebutton:
-                            idle LiveComposite((150, 130), (50, 20), "mod_assets/mod_extra_images/gallery.png", (40, 75), Text("Gallery", style="extras_text"))
-                            hover LiveComposite((150, 130), (50, 20), "mod_assets/mod_extra_images/gallery.png", (38, 73), Text("Gallery", style="extras_hover_text"))
+                            idle Composite((150, 130), (50, 20), "mod_assets/mod_extra_images/gallery.png", (40, 75), Text("Gallery", style="extras_text"))
+                            hover Composite((150, 130), (50, 20), "mod_assets/mod_extra_images/gallery.png", (38, 73), Text("Gallery", style="extras_hover_text"))
                             action ShowMenu("gallery")
                 frame:
                     xsize 160
@@ -42,8 +42,8 @@ screen extras():
                         xalign 0.5
                         yalign 0.5
                         imagebutton:
-                            idle LiveComposite((150, 130), (50, 20), "mod_assets/mod_extra_images/achievements.png", (40, 75), Text("Awards", style="extras_text"))
-                            hover LiveComposite((150, 130), (50, 20), "mod_assets/mod_extra_images/achievements.png", (38, 73), Text("Awards", style="extras_hover_text"))
+                            idle Composite((150, 130), (50, 20), "mod_assets/mod_extra_images/achievements.png", (40, 75), Text("Awards", style="extras_text"))
+                            hover Composite((150, 130), (50, 20), "mod_assets/mod_extra_images/achievements.png", (38, 73), Text("Awards", style="extras_hover_text"))
                             action ShowMenu("achievements")
 
                 # frame:
@@ -54,8 +54,8 @@ screen extras():
                 #         xalign 0.5
                 #         yalign 0.5
                 #         imagebutton:
-                #             idle LiveComposite((150, 130), (50, 20), "mod_assets/mod_extra_images/ost_player.png", (40, 75), Text("DDLC OST-Player", style="extras_text"))
-                #             hover LiveComposite((150, 130), (50, 20), "mod_assets/mod_extra_images/ost_player.png", (38, 73), Text("DDLC OST-Player", style="extras_hover_text"))
+                #             idle Composite((150, 130), (50, 20), "mod_assets/mod_extra_images/ost_player.png", (40, 75), Text("DDLC OST-Player", style="extras_text"))
+                #             hover Composite((150, 130), (50, 20), "mod_assets/mod_extra_images/ost_player.png", (38, 73), Text("DDLC OST-Player", style="extras_hover_text"))
                 #             action [ShowMenu("new_music_room"), Function(ost_start)]
 
             vbar value YScrollValue("ext") xalign 0.99 ysize 560


### PR DESCRIPTION
LiveComposite is obsolete as of now. Did you keep it for older version of RenPy?