### PR TITLE
fixed an indexing error on splash.rpy

### DIFF
--- a/game/splash.rpy
+++ b/game/splash.rpy
@@ -306,14 +306,14 @@ label splashscreen:
                 try:
                     process_list = subprocess.check_output("powershell (Get-Process).ProcessName", shell=True).lower().replace("\r", "").split("\n") # For W11 builds > 22000
                     
-                    for x in enumerate(process_list):
+                    for x, _ in enumerate(process_list):
                         process_list[x] += ".exe"
                 except subprocess.CalledProcessError: pass            
         else:
             try: process_list = subprocess.check_output("ps -A --format cmd", shell=True).split(b"\n") # Linux
             except subprocess.CalledProcessError: process_list = subprocess.check_output("ps -A -o command", shell=True).split(b"\n") # MacOS
                 
-            for x in enumerate(process_list):
+            for x, _ in enumerate(process_list):
                 process_list[x] = process_list[x].decode('utf-8').split("/")[-1]
             process_list.pop(0)
 


### PR DESCRIPTION
It was generating a fatal error when trying to launch the mod:

```
Full traceback:
  File "renpy/common/00start.rpy", line 233, in script call
    call _splashscreen from _call_splashscreen_1
  File "game/splash.rpy", line 299, in script
    python:
  File "/usr/share/renpy/renpy/ast.py", line 928, in execute
    renpy.python.py_exec_bytecode(self.code.bytecode, self.hide, store=self.store)
  File "/usr/share/renpy/renpy/python.py", line 2245, in py_exec_bytecode
    exec(bytecode, globals, locals)
  File "game/splash.rpy", line 317, in <module>
    process_list[x] = process_list[x].decode('utf-8').split("/")[-1]
TypeError: list indices must be integers, not tuple

While running game code:
  File "renpy/common/00start.rpy", line 233, in script call
    call _splashscreen from _call_splashscreen_1
  File "game/splash.rpy", line 299, in script
    python:
  File "game/splash.rpy", line 317, in <module>
    process_list[x] = process_list[x].decode('utf-8').split("/")[-1]
TypeError: list indices must be integers, not tuple
```