### PR TITLE
fix division issue

### DIFF
--- a/game/effects.rpy
+++ b/game/effects.rpy
@@ -92,7 +92,7 @@ init python:
             self.pieces = []
             tearpoints = [0, self.height]
             for i in range(number):
-                tearpoints.append(random.randint(10, self.height - 10))
+                tearpoints.append(random.randint(10, int(self.height) - 10))
             tearpoints.sort()
             for i in range(number+1):
                 self.pieces.append(TearPiece(tearpoints[i], tearpoints[i+1], offtimeMult, ontimeMult, offsetMin, offsetMax))


### PR DESCRIPTION
in r7, `self.height` would always be an integer since py2 div sucks

issue is that it is used in `random.randint` and in py3, division is always float division

this pr fixes it by using `int(self.height)` inside the function