### PR TITLE
allow tear effect to be saved

### DIFF
--- a/Additional Mod Features/Better Screen Tear/effects_tear.rpy
+++ b/Additional Mod Features/Better Screen Tear/effects_tear.rpy
@@ -41,15 +41,17 @@ init 10 python:
         `srf`: Render | Surface | GL2Model | None
             The surface used. If `None` is passed, takes a screenshot and uses it as surface
             (the screenshot's size doesn't exactly match the screen's size, careful with that).
-        
-        Saving while a displayable like this is showing isn't possible.
         """
         def __init__(self, number=10, offtimeMult=1, ontimeMult=1, offsetRange=(0, 50), chroma=False, render_child=True, srf=None):
             super(TearSurface, self).__init__(number, offtimeMult, ontimeMult, offsetRange, chroma, render_child)
-            self.srf = srf or screenshot_srf()
-        
+            srf = srf or renpy.display.draw.screenshot(None)
+
+            with io.BytesIO() as sio:
+                renpy.display.module.save_png(srf, sio, 0)
+                self.data = sio.getvalue()
+
         def render(self, w, h, st, at):
-            return self._srf_render(self.srf, w, h, st, at)
+            return self._srf_render(renpy.display.pgrender.load_image(io.BytesIO(self.data), "TearSurface.png"), w, h, st, at)
     
     def Tear(number=10, offtimeMult=1, ontimeMult=1, offsetMin=0, offsetMax=50, srf=None, chroma=False):
         return TearSurface(number, offtimeMult, ontimeMult, (offsetMin, offsetMax), chroma, srf)

--- a/Additional Mod Features/Better Screen Tear/effects_tear.rpy
+++ b/Additional Mod Features/Better Screen Tear/effects_tear.rpy
@@ -44,7 +44,7 @@ init 10 python:
         """
         def __init__(self, number=10, offtimeMult=1, ontimeMult=1, offsetRange=(0, 50), chroma=False, render_child=True, srf=None):
             super(TearSurface, self).__init__(number, offtimeMult, ontimeMult, offsetRange, chroma, render_child)
-            srf = srf or renpy.display.draw.screenshot(None)
+            srf = srf or screenshot_srf()
 
             with io.BytesIO() as sio:
                 renpy.display.module.save_png(srf, sio, 0)


### PR DESCRIPTION
- convert the `Surface` / `Render` to bytes
- render it the way `im.Data` does