### PR TITLE
replace all obsolete appeal variable (Py3)

### DIFF
--- a/Original Script Files/script-ch1.rpy
+++ b/Original Script Files/script-ch1.rpy
@@ -129,7 +129,7 @@ label ch1_main:
     "Meanwhile, Natsuki is rummaging around in the closet."
 
 
-    $ nextscene = poemwinner[0] + "_exclusive_" + str(eval(poemwinner[0][0] + "_appeal"))
+    $ nextscene = poemwinner[0] + "_exclusive_" + str(eval("chibi_" + poemwinner[0][0] + ".appeal"))
     call expression nextscene
 
 

--- a/Original Script Files/script-ch2.rpy
+++ b/Original Script Files/script-ch2.rpy
@@ -334,7 +334,7 @@ label ch2_main:
 
 
 
-    $ nextscene = poemwinner[1] + "_exclusive_" + str(eval(poemwinner[1][0] + "_appeal"))
+    $ nextscene = poemwinner[1] + "_exclusive_" + str(eval("chibi_" + poemwinner[1][0] + ".appeal"))
     call expression nextscene
 
 

--- a/Original Script Files/script-ch21.rpy
+++ b/Original Script Files/script-ch21.rpy
@@ -86,7 +86,7 @@ label ch21_main:
     "Meanwhile, Natsuki is rummaging around in the closet."
 
 
-    $ nextscene = poemwinner[0] + "_exclusive2_" + str(eval(poemwinner[0][0] + "_appeal"))
+    $ nextscene = poemwinner[0] + "_exclusive2_" + str(eval("chibi_" + poemwinner[0][0] + ".appeal"))
     call expression nextscene
 
     return

--- a/Original Script Files/script-ch22.rpy
+++ b/Original Script Files/script-ch22.rpy
@@ -235,12 +235,12 @@ label ch22_main:
     y "I was wondering if you would like to spend some time together today."
     y 3o "I mean--in the club!"
     if poemwinner[0] == "natsuki":
-        $ y_appeal = 1
+        $ chibi_y.appeal = 1
         mc "Ah, I suppose so."
         mc "I don't think I could say no to you, after you gave that book to me."
         mc "Well, I guess I need to make sure Natsuki isn't waiting for me."
         mc "After we finished reading yesterday, she--"
-        if n_appeal >= 2:
+        if chibi_n.appeal >= 2:
             y 3r "She's fine!"
             $ style.say_dialogue = style.normal
             y 3h "She's reading over there. See?"
@@ -264,7 +264,7 @@ label ch22_main:
             mc "Ah--"
             mc "In that case, I don't see any problem..."
     else:
-        $ y_appeal = 2
+        $ chibi_y.appeal = 2
         mc "Yeah, definitely."
         mc "I planned on it anyway."
     show yuri zorder 2 at h11
@@ -292,7 +292,7 @@ label ch22_main2:
     scene bg club_day2
     show yuri 3a at i11
     with wipeleft
-    $ nextscene = "yuri_exclusive2_" + str(eval("y_appeal")) + "_ch22"
+    $ nextscene = "yuri_exclusive2_" + str(eval("chibi_y.appeal")) + "_ch22"
     call expression nextscene
 
     return

--- a/Original Script Files/script-ch23.rpy
+++ b/Original Script Files/script-ch23.rpy
@@ -66,7 +66,7 @@ label ch23_main:
     n 1q "You say that like I do it on a regular basis or something."
     n "I just wasn't paying attention, okay? I'm sorry."
     n 4u "Seriously... What's gotten into you lately?"
-    if n_appeal >= 2:
+    if chibi_n.appeal >= 2:
         n "Look..."
         n "I did some thinking about yesterday."
         n 2q "I was a little more hostile than I meant to be..."
@@ -238,7 +238,7 @@ label ch23_main:
     y 2u "Um... Thank you for understanding, Monika."
     if poemwinner[2] == "natsuki":
         $ poemwinner[2] = "yuri"
-        $ y_appeal += 1
+        $ chibi_y.appeal += 1
 
     scene bg club_day2
     show yuri 3 zorder 2 at t11
@@ -266,7 +266,7 @@ label ch23_end:
     m "Okay, everyone!"
     m "It's time to figure out the festival preparations."
     m 1i "Let's hurry and get this over with."
-    if n_appeal >= 2:
+    if chibi_n.appeal >= 2:
         show natsuki 4q zorder 3 at f31
         n "..."
     else:
@@ -282,7 +282,7 @@ label ch23_end:
     show monika zorder 3 at f32
     m 2r "Look, can we just get this done?"
     m 2d "I'm going to be printing and assembling all the poetry pamphlets."
-    if n_appeal >= 2:
+    if chibi_n.appeal >= 2:
         m 2i "Natsuki, you can make cupcakes."
         m "I know you're at least good at that."
         show monika zorder 2 at t32

--- a/Original Script Files/script-ch3.rpy
+++ b/Original Script Files/script-ch3.rpy
@@ -188,11 +188,11 @@ label ch3_main:
 
 
 
-    if n_appeal == 0 and y_appeal == 0:
+    if chibi_n.appeal == 0 and chibi_y.appeal == 0:
         jump ch3_start_none
-    elif n_appeal > 1:
+    elif chibi_n.appeal > 1:
         jump ch3_start_natsuki
-    elif y_appeal > 1:
+    elif chibi_y.appeal > 1:
         jump ch3_start_yuri
     elif poemwinner[1] == "natsuki":
         jump ch3_start_natsuki

--- a/Original Script Files/script-poemresponses2.rpy
+++ b/Original Script Files/script-poemresponses2.rpy
@@ -52,7 +52,7 @@ label ch23_y_end:
 label ch21_n_end:
     jump ch1_n_end
 label ch22_n_end:
-    if n_appeal >= 2:
+    if chibi_n.appeal >= 2:
         jump ch22_n_end2
     else:
         call showpoem (poem_n2)
@@ -594,7 +594,7 @@ label ch21_m_start:
     mc "Yeah, that's true."
     "I hand Monika my poem."
     m 2a "...Mhm!"
-    $ nextscene = "m2_" + poemwinner[0] + "_" + str(eval(poemwinner[0][0] + "_appeal"))
+    $ nextscene = "m2_" + poemwinner[0] + "_" + str(eval("chibi_" + poemwinner[0][0] + ".appeal"))
     call expression nextscene
 
     m 1a "Anyway, do you want to read my poem now?"
@@ -607,7 +607,7 @@ label ch21_m_start:
     return
 
 label ch22_m_start:
-    if y_appeal < 2:
+    if chibi_y.appeal < 2:
         m 1b "Hi again, [player]!"
         m "How's the writing going?"
         mc "Alright, I guess..."
@@ -622,7 +622,7 @@ label ch22_m_start:
         "I give my poem to Monika."
         m "..."
         m "...Alright!"
-    $ nextscene = "m2_yuri_" + str(eval("y_appeal"))
+    $ nextscene = "m2_yuri_" + str(eval("chibi_y.appeal"))
     call expression nextscene
 
     m 1a "But anyway..."
@@ -631,9 +631,9 @@ label ch22_m_start:
     return
 
 label ch23_m_start:
-    $ nextscene = "m2_yuri_" + str(eval("y_appeal"))
+    $ nextscene = "m2_yuri_" + str(eval("chibi_y.appeal"))
     call expression nextscene
-    if y_appeal < 3:
+    if chibi_y.appeal < 3:
         m 1a "Anyway..."
         if y_gave:
             m 1m "I guess we won't worry about your poem..."

--- a/game/poem_responses/script-poemresponses.rpy
+++ b/game/poem_responses/script-poemresponses.rpy
@@ -318,7 +318,7 @@ label ch2_y_end:
     y 2u "I-I might be ranting a little bit now..."
     y "...But I'm glad that you're a good listener."
     # This if statement checks if Yuri's appeal to your poems is 2 or more.
-    if y_appeal >= 2:
+    if chibi_y.appeal >= 2:
         y 2s "You're good at a lot of things..."
         y "Writing, listening..."
         y 2u "There really aren't many people like you, [player]..."
@@ -338,7 +338,7 @@ label ch3_y_end:
     $ y_read3 = True
     # This if statement checks if Yuri's appeal is 3 or more to call her
     # special poem instead.
-    if y_appeal >= 3:
+    if chibi_y.appeal >= 3:
         jump ch3_y_end_special
     call showpoem (poem_y3, img="yuri 2v")
     y "Um..."
@@ -346,7 +346,7 @@ label ch3_y_end:
     y "But I did my best to take a metaphorical approach to it."
     # This if/else statement checks if you did not read Natsuki's special poem
     # or if her poem appeal is 3 or more.
-    if not n_read3 or n_appeal >= 3:
+    if not n_read3 or chibi_n.appeal >= 3:
         mc "You say that like you didn't even want to write about it..."
         y 2e "Oh, you haven't heard...?"
         y 2h "After yesterday, Natsuki and I...well..."
@@ -517,7 +517,7 @@ label ch2_n_end:
         mc "Well, you're definitely right."
         mc "At least, I can relate to that."
         mc "And I'm sure a lot of other people can, too."
-    if n_appeal >= 2:
+    if chibi_n.appeal >= 2:
         n 4h "You know..."
         n "I'm glad that you can appreciate this kind of writing..."
         n 4q "I mean...I know I was talking about that yesterday."
@@ -542,14 +542,14 @@ label ch2_n_end:
 label ch3_n_end:
     $ n_read3 = True
 
-    if n_appeal >= 3:
+    if chibi_n.appeal >= 3:
         jump ch3_n_end_special
     call showpoem (poem_n3)
     n 2a "Yeah..."
     n "I felt like I kept writing about negative things, so I wanted to write something with a nice message for once."
     n 2z "Besides...the beach is awesome!"
     n 2j "Kinda hard to write anything negative about the beach."
-    if not y_read3 or y_appeal >= 3:
+    if not y_read3 or chibi_y.appeal >= 3:
         mc "So you decided to write about the beach first, and then came up with the message later?"
         n 2c "Yeah, well..."
         n "It's only because of what happened yesterday."
@@ -2431,7 +2431,7 @@ label ch1_m_start:
     m 2a "...Mhm!"
     # This variable and call expression statement sets the 'nextscene' variable to
     # the character you wrote your poem to and calls it.
-    $ nextscene = "m_" + poemwinner[0] + "_" + str(eval(poemwinner[0][0] + "_appeal"))
+    $ nextscene = "m_" + poemwinner[0] + "_" + str(eval("chibi_" + poemwinner[0][0] + ".appeal"))
     call expression nextscene
 
     mc "I'm sure I'll end up trying different things a lot."
@@ -2481,7 +2481,7 @@ label ch2_m_start:
         "I give my poem to Monika."
         m "..."
         m "...Alright!"
-        $ nextscene = "m_" + poemwinner[1] + "_" + str(eval(poemwinner[1][0] + "_appeal"))
+        $ nextscene = "m_" + poemwinner[1] + "_" + str(eval("chibi_" + poemwinner[1][0] + ".appeal"))
         call expression nextscene
 
         m 1a "But anyway..."
@@ -2509,7 +2509,7 @@ label ch3_m_start:
         mc "Sure..."
         "I let Monika take the poem I'm holding in my hands."
         m "..."
-        $ nextscene = "m_" + poemwinner[2] + "_" + str(eval(poemwinner[2][0] + "_appeal"))
+        $ nextscene = "m_" + poemwinner[2] + "_" + str(eval("chibi_" + poemwinner[2][0] + ".appeal"))
         call expression nextscene
 
         m 1a "Anyway...!"

--- a/game/script.rpy
+++ b/game/script.rpy
@@ -162,7 +162,7 @@ label start:
 
     #         # This if statement calls either a special poem response game or play
     #         # as normal.
-    #         if y_appeal >= 3:
+    #         if chibi_y.appeal >= 3:
     #             call poemresponse_start2
     #         else:
     #             call poemresponse_start


### PR DESCRIPTION
This PR is a continuation of #68. The better poemgame replaces `*_appeal` variables with `chibi_*.appeal`, but the `*_appeal` variables are also used in other scripts.

I replace all `*_appeal` variables with `chibi_*.appeal`. Otherwise, the game raises an exception like `NameError: 's_appeal' is not defined`.

I am not sure if I should modify Original Script Files. If they shouldn't be modified, I shall revert those changes. Also I plan to make another PR for `python-2` branch.