### PR TITLE
replace all obsolete appeal variable (Py2)

### DIFF
--- a/Original Game Scripts/script-ch1.rpy
+++ b/Original Game Scripts/script-ch1.rpy
@@ -129,7 +129,7 @@ label ch1_main:
     "Meanwhile, Natsuki is rummaging around in the closet."
 
 
-    $ nextscene = poemwinner[0] + "_exclusive_" + str(eval(poemwinner[0][0] + "_appeal"))
+    $ nextscene = poemwinner[0] + "_exclusive_" + str(eval("chibi_" + poemwinner[0][0] + ".appeal"))
     call expression nextscene
 
 

--- a/Original Game Scripts/script-ch2.rpy
+++ b/Original Game Scripts/script-ch2.rpy
@@ -334,7 +334,7 @@ label ch2_main:
 
 
 
-    $ nextscene = poemwinner[1] + "_exclusive_" + str(eval(poemwinner[1][0] + "_appeal"))
+    $ nextscene = poemwinner[1] + "_exclusive_" + str(eval("chibi_" + poemwinner[1][0] + ".appeal"))
     call expression nextscene
 
 

--- a/Original Game Scripts/script-ch21.rpy
+++ b/Original Game Scripts/script-ch21.rpy
@@ -86,7 +86,7 @@ label ch21_main:
     "Meanwhile, Natsuki is rummaging around in the closet."
 
 
-    $ nextscene = poemwinner[0] + "_exclusive2_" + str(eval(poemwinner[0][0] + "_appeal"))
+    $ nextscene = poemwinner[0] + "_exclusive2_" + str(eval("chibi_" + poemwinner[0][0] + ".appeal"))
     call expression nextscene
 
     return

--- a/Original Game Scripts/script-ch22.rpy
+++ b/Original Game Scripts/script-ch22.rpy
@@ -235,12 +235,12 @@ label ch22_main:
     y "I was wondering if you would like to spend some time together today."
     y 3o "I mean--in the club!"
     if poemwinner[0] == "natsuki":
-        $ y_appeal = 1
+        $ chibi_y.appeal = 1
         mc "Ah, I suppose so."
         mc "I don't think I could say no to you, after you gave that book to me."
         mc "Well, I guess I need to make sure Natsuki isn't waiting for me."
         mc "After we finished reading yesterday, she--"
-        if n_appeal >= 2:
+        if chibi_n.appeal >= 2:
             y 3r "She's fine!"
             $ style.say_dialogue = style.normal
             y 3h "She's reading over there. See?"
@@ -264,7 +264,7 @@ label ch22_main:
             mc "Ah--"
             mc "In that case, I don't see any problem..."
     else:
-        $ y_appeal = 2
+        $ chibi_y.appeal = 2
         mc "Yeah, definitely."
         mc "I planned on it anyway."
     show yuri zorder 2 at h11
@@ -292,7 +292,7 @@ label ch22_main2:
     scene bg club_day2
     show yuri 3a at i11
     with wipeleft
-    $ nextscene = "yuri_exclusive2_" + str(eval("y_appeal")) + "_ch22"
+    $ nextscene = "yuri_exclusive2_" + str(eval("chibi_y.appeal")) + "_ch22"
     call expression nextscene
 
     return

--- a/Original Game Scripts/script-ch23.rpy
+++ b/Original Game Scripts/script-ch23.rpy
@@ -66,7 +66,7 @@ label ch23_main:
     n 1q "You say that like I do it on a regular basis or something."
     n "I just wasn't paying attention, okay? I'm sorry."
     n 4u "Seriously... What's gotten into you lately?"
-    if n_appeal >= 2:
+    if chibi_n.appeal >= 2:
         n "Look..."
         n "I did some thinking about yesterday."
         n 2q "I was a little more hostile than I meant to be..."
@@ -238,7 +238,7 @@ label ch23_main:
     y 2u "Um... Thank you for understanding, Monika."
     if poemwinner[2] == "natsuki":
         $ poemwinner[2] = "yuri"
-        $ y_appeal += 1
+        $ chibi_y.appeal += 1
 
     scene bg club_day2
     show yuri 3 zorder 2 at t11
@@ -266,7 +266,7 @@ label ch23_end:
     m "Okay, everyone!"
     m "It's time to figure out the festival preparations."
     m 1i "Let's hurry and get this over with."
-    if n_appeal >= 2:
+    if chibi_n.appeal >= 2:
         show natsuki 4q zorder 3 at f31
         n "..."
     else:
@@ -282,7 +282,7 @@ label ch23_end:
     show monika zorder 3 at f32
     m 2r "Look, can we just get this done?"
     m 2d "I'm going to be printing and assembling all the poetry pamphlets."
-    if n_appeal >= 2:
+    if chibi_n.appeal >= 2:
         m 2i "Natsuki, you can make cupcakes."
         m "I know you're at least good at that."
         show monika zorder 2 at t32

--- a/Original Game Scripts/script-ch3.rpy
+++ b/Original Game Scripts/script-ch3.rpy
@@ -188,11 +188,11 @@ label ch3_main:
 
 
 
-    if n_appeal == 0 and y_appeal == 0:
+    if chibi_n.appeal == 0 and chibi_y.appeal == 0:
         jump ch3_start_none
-    elif n_appeal > 1:
+    elif chibi_n.appeal > 1:
         jump ch3_start_natsuki
-    elif y_appeal > 1:
+    elif chibi_y.appeal > 1:
         jump ch3_start_yuri
     elif poemwinner[1] == "natsuki":
         jump ch3_start_natsuki

--- a/Original Game Scripts/script-poemresponses2.rpy
+++ b/Original Game Scripts/script-poemresponses2.rpy
@@ -52,7 +52,7 @@ label ch23_y_end:
 label ch21_n_end:
     jump ch1_n_end
 label ch22_n_end:
-    if n_appeal >= 2:
+    if chibi_n.appeal >= 2:
         jump ch22_n_end2
     else:
         $ show_poem (poem_n2)
@@ -594,7 +594,7 @@ label ch21_m_start:
     mc "Yeah, that's true."
     "I hand Monika my poem."
     m 2a "...Mhm!"
-    $ nextscene = "m2_" + poemwinner[0] + "_" + str(eval(poemwinner[0][0] + "_appeal"))
+    $ nextscene = "m2_" + poemwinner[0] + "_" + str(eval("chibi_" + poemwinner[0][0] + ".appeal"))
     call expression nextscene
 
     m 1a "Anyway, do you want to read my poem now?"
@@ -607,7 +607,7 @@ label ch21_m_start:
     return
 
 label ch22_m_start:
-    if y_appeal < 2:
+    if chibi_y.appeal < 2:
         m 1b "Hi again, [player]!"
         m "How's the writing going?"
         mc "Alright, I guess..."
@@ -622,7 +622,7 @@ label ch22_m_start:
         "I give my poem to Monika."
         m "..."
         m "...Alright!"
-    $ nextscene = "m2_yuri_" + str(eval("y_appeal"))
+    $ nextscene = "m2_yuri_" + str(eval("chibi_y.appeal"))
     call expression nextscene
 
     m 1a "But anyway..."
@@ -631,9 +631,9 @@ label ch22_m_start:
     return
 
 label ch23_m_start:
-    $ nextscene = "m2_yuri_" + str(eval("y_appeal"))
+    $ nextscene = "m2_yuri_" + str(eval("chibi_y.appeal"))
     call expression nextscene
-    if y_appeal < 3:
+    if chibi_y.appeal < 3:
         m 1a "Anyway..."
         if y_gave:
             m 1m "I guess we won't worry about your poem..."

--- a/game/definitions/definitions.rpy
+++ b/game/definitions/definitions.rpy
@@ -1542,12 +1542,6 @@ default m_readpoem = False
 # This variable keeps track on how many people have read your poem.
 default poemsread = 0
 
-# These variables store the appeal a character has to your poem
-default n_appeal = 0
-default s_appeal = 0
-default y_appeal = 0
-default m_appeal = 0
-
 # These variables control if we have seen Natsuki's or Yuri's exclusive scenes
 default n_exclusivewatched = False
 default y_exclusivewatched = False

--- a/game/poem_responses/script-poemresponses.rpy
+++ b/game/poem_responses/script-poemresponses.rpy
@@ -2431,7 +2431,7 @@ label ch1_m_start:
     m 2a "...Mhm!"
     # This variable and call expression statement sets the 'nextscene' variable to
     # the character you wrote your poem to and calls it.
-    $ nextscene = "m_" + poemwinner[0] + "_" + str(eval(poemwinner[0][0] + "_appeal"))
+    $ nextscene = "m_" + poemwinner[0] + "_" + str(eval("chibi_" + poemwinner[0][0] + ".appeal"))
     call expression nextscene
 
     mc "I'm sure I'll end up trying different things a lot."
@@ -2481,7 +2481,7 @@ label ch2_m_start:
         "I give my poem to Monika."
         m "..."
         m "...Alright!"
-        $ nextscene = "m_" + poemwinner[1] + "_" + str(eval(poemwinner[1][0] + "_appeal"))
+        $ nextscene = "m_" + poemwinner[1] + "_" + str(eval("chibi_" + poemwinner[1][0] + ".appeal"))
         call expression nextscene
 
         m 1a "But anyway..."
@@ -2509,7 +2509,7 @@ label ch3_m_start:
         mc "Sure..."
         "I let Monika take the poem I'm holding in my hands."
         m "..."
-        $ nextscene = "m_" + poemwinner[2] + "_" + str(eval(poemwinner[2][0] + "_appeal"))
+        $ nextscene = "m_" + poemwinner[2] + "_" + str(eval("chibi_" + poemwinner[2][0] + ".appeal"))
         call expression nextscene
 
         m 1a "Anyway...!"

--- a/game/script.rpy
+++ b/game/script.rpy
@@ -170,7 +170,7 @@ label start:
 
     #         # This if statement calls either a special poem response game or play
     #         # as normal.
-    #         if y_appeal >= 3:
+    #         if chibi_y.appeal >= 3:
     #             call poemresponse_start2
     #         else:
     #             call poemresponse_start


### PR DESCRIPTION
The Py2 version of #78, continuing #69. Replace all `*_appeal` variables with `chibi_*.appeal` in case of `NameError: 's_appeal' is not defined` exception. I haven't tested on Py2 though.